### PR TITLE
Do not delete saved filters

### DIFF
--- a/Controller/Adminhtml/Reset/Index.php
+++ b/Controller/Adminhtml/Reset/Index.php
@@ -39,6 +39,7 @@ class Index extends \Magento\Backend\App\Action
         try {
             $collection = $this->bookmarkFactory->create()->getCollection();
             $collection->addFieldToFilter('user_id', ['eq' => $userId]);
+            $collection->addFieldToFilter('identifier', ['eq' => 'current']);
 
             foreach ($collection->getItems() as $bookmark) {
                 $this->bookmarkRepository->deleteById($bookmark->getBookmarkId());


### PR DESCRIPTION
Saved filters are saved in the same table, with `identifier` following the pattern `_<timestamp>` (e.g.: `_1569839952978`). This pull request makes sure only the `current` filters are deleted.